### PR TITLE
Add Docker setup for Portainer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 4173
+CMD ["serve", "-s", "dist", "-l", "4173"]

--- a/README.md
+++ b/README.md
@@ -67,3 +67,14 @@ export default tseslint.config([
   },
 ])
 ```
+
+## Running with Docker
+
+This repository includes a `docker-compose.yml` file for use with Portainer's **Git repository** deployment feature. The image is built using the provided `Dockerfile` and serves the production build on port `4173`.
+
+```bash
+# build and run locally
+docker compose up --build
+```
+
+When deploying through Portainer, select this repository and use `docker-compose.yml` as the stack file. After deployment the application will be available on port `4173` of the container host.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  web:
+    build: .
+    ports:
+      - "4173:4173"


### PR DESCRIPTION
## Summary
- add Dockerfile for building and serving the project
- add docker-compose.yml stack for Portainer deployment
- ignore non-required files in `.dockerignore`
- document running via Docker in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6863bf2adb8483318fe92d2e8d4ab8b4